### PR TITLE
Surface Build and Publish Errors to the Output Console

### DIFF
--- a/src/extension/executeProjectNpmScript.ts
+++ b/src/extension/executeProjectNpmScript.ts
@@ -5,6 +5,11 @@ import { promisify } from "node:util";
 import * as vscode from "vscode";
 import { findNpmPath } from "@/extension/findNpmPath";
 
+type ExecError = Error & {
+  stdout?: string;
+  stderr?: string;
+};
+
 const execAsync = promisify(exec);
 
 export const executeProjectNpmScript = async (
@@ -46,7 +51,9 @@ export const executeProjectNpmScript = async (
 
     return { stdout, stderr };
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const execError = error as ExecError;
+    const errorMessage = execError.message || String(error);
+    const errorStdOut = (execError.stdout || "").replace(/^\n+/, "");
 
     if (
       errorMessage.includes("command not found") ||
@@ -58,7 +65,7 @@ export const executeProjectNpmScript = async (
     }
 
     throw new Error(
-      `Failed to execute npm script '${scriptName}': ${errorMessage}`
+      `Failed to execute npm script '${scriptName}': ${errorMessage} \n ${errorStdOut}`
     );
   }
 };


### PR DESCRIPTION
When running the import command, the process builds the integration and then imports it into the Prismatic application. However, if a build error occurs, this is not surfaced clearly to the user. Instead, the failure appears as a generic import error, which is confusing and misleading.

- Detect when an import command fails due to a build error.
- Display the build error message directly to the user instead of a generic failure message.

https://app.shortcut.com/prismatic/story/29586/feedback-surface-build-and-publish-errors-to-the-output-console?vc_group_by=day&ct_workflow=all&cf_workflow=500000005


<img width="2287" height="1336" alt="image" src="https://github.com/user-attachments/assets/4ef6c4c1-24ca-4387-afb9-569e94dc186e" />
