### PR TITLE
Update refresh token command to better illustrate implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ src/
 
 - `prismatic.configWizard`: Open the Config Wizard
 - `prismatic.me`: View your user profile
-- `prismatic.me:token`: Refresh your authentication token
+- `prismatic.refreshToken`: Refresh your authentication token
 - `prismatic.login`: Log in to Prismatic
 - `prismatic.logout`: Log out of Prismatic
 - `prismatic.integrations.import`: Import an integration

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "category": "Prismatic"
       },
       {
-        "command": "prismatic.me:token",
+        "command": "prismatic.refreshToken",
         "title": "Refresh Token",
         "category": "Prismatic"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,11 +168,11 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(prismLogoutCommand);
 
     /**
-     * command: prism me:token
+     * command: PRISM_REFRESH_TOKEN=${globalState.refreshToken} prism me:token
      * This command is used to refresh the access token.
      */
-    const prismMeTokenCommand = vscode.commands.registerCommand(
-      "prismatic.me:token",
+    const prismRefreshTokenCommand = vscode.commands.registerCommand(
+      "prismatic.refreshToken",
       async () => {
         try {
           await tokenManager.refreshAccessToken();
@@ -183,7 +183,7 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       }
     );
-    context.subscriptions.push(prismMeTokenCommand);
+    context.subscriptions.push(prismRefreshTokenCommand);
 
     /**
      * command: prism integrations:import


### PR DESCRIPTION
Updated the refresh token command to better illustrate its intended use. Previously it was prism me:token, but since that command could be used in multiple contexts, I revised the name to make its purpose clearer.