### PR TITLE
Resolve prismatic URL: prefer PRISMATIC_URL node env, fallback to prod, then prism if set

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ const CONFIG = {
       viewType: "configWizard.webview",
     },
   },
-  prismaticUrl: "https://app.dev.prismatic-dev.io",
+  prismaticUrl: "https://app.prismatic.io",
 };
 
 module.exports = { CONFIG };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
   testIntegrationFlowMachine,
   type TestIntegrationFlowMachineActorRef,
 } from "./lib/integrationsFlowsTest/testIntegrationFlow.machine";
+import { syncPrismaticUrl } from "@/extension/syncPrismaticUrl";
 
 // disposables
 let executionResultsViewProvider: vscode.Disposable | undefined;
@@ -104,6 +105,8 @@ export async function activate(context: vscode.ExtensionContext) {
     } catch (error) {
       log("ERROR", String(error), true);
     }
+
+    await syncPrismaticUrl();
 
     /**
      * register views

--- a/src/extension/StateManager.ts
+++ b/src/extension/StateManager.ts
@@ -9,7 +9,7 @@ const GLOBAL_STATE_KEY = "prismatic-global-state";
 const DEFAULT_GLOBAL_STATE: GlobalState = {
   accessToken: undefined,
   refreshToken: undefined,
-  prismaticUrl: CONFIG.prismaticUrl,
+  prismaticUrl: process.env.PRISMATIC_URL || CONFIG.prismaticUrl,
 };
 
 const WORKSPACE_STATE_KEY = "prismatic-workspace-state";

--- a/src/extension/syncPrismaticUrl.ts
+++ b/src/extension/syncPrismaticUrl.ts
@@ -1,0 +1,32 @@
+import { log } from "@/extension";
+import { StateManager } from "@/extension/StateManager";
+
+export const syncPrismaticUrl = async (): Promise<void> => {
+	// step 1. check if prismatic url is already in global state
+	const stateManager = StateManager.getInstance();
+	const globalStatePrismaticUrl = (await stateManager.getGlobalState())
+		?.prismaticUrl;
+
+	// step 2. get env prismatic url
+	const envVariablePrismaticUrl = process.env.PRISMATIC_URL;
+
+	if (envVariablePrismaticUrl) {
+		// check if in sync
+		if (envVariablePrismaticUrl === globalStatePrismaticUrl) {
+			return;
+		}
+
+		log(
+			"INFO",
+			`Prismatic URL is out of sync, updating global state...
+    - Global State: ${globalStatePrismaticUrl}
+    - Env Variable: ${envVariablePrismaticUrl} (new)
+    `,
+		);
+
+		// update global state
+		await stateManager.updateGlobalState({
+			prismaticUrl: envVariablePrismaticUrl,
+		});
+	}
+};


### PR DESCRIPTION
When installing the extension, it currently defaults to authenticating against the dev stack. Since users are likely already authenticated in Prism when initializing the CNI, we should attempt to pull their Prismatic URL directly from their existing authentication. If this doesn't exists, we'll fallback to the production stack.