### PR TITLE
Prevent DEBUG env var from propagating to SDK CLI calls

### DIFF
--- a/src/extension/PrismCLIManager.ts
+++ b/src/extension/PrismCLIManager.ts
@@ -76,6 +76,8 @@ export class PrismCLIManager {
           env: {
             ...process.env,
             PRISMATIC_URL: globalState.prismaticUrl,
+            // note: explicitly override DEBUG to prevent Node's require from dumping debug data when CNI projects set DEBUG=true via dotenv
+            DEBUG: "false",
           },
         }
       );

--- a/src/extension/executeProjectNpmScript.ts
+++ b/src/extension/executeProjectNpmScript.ts
@@ -41,6 +41,11 @@ export const executeProjectNpmScript = async (
       `"${npmPath}" run ${scriptName}`,
       {
         cwd: workspaceFolder.uri.fsPath,
+        env: {
+          ...process.env,
+          // note: explicitly override DEBUG to prevent Node's require from dumping debug data when CNI projects set DEBUG=true via dotenv
+          DEBUG: "false",
+        },
       }
     );
 


### PR DESCRIPTION
#### Problem
The VSCode extension was inheriting the `DEBUG=true` environment variable from projects using dotenv, causing the SDK CLI to output verbose debug information during command execution.

#### Solution
Within the VS Code extension, I override incoming environment variables from the CNI project before executing commands both from the project itself and the SDK. This prevents Node’s require built-in DEBUG output from being enabled.