### PR TITLE
Remove manual token refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,12 +97,6 @@
         "enablement": "prismatic.workspaceEnabled"
       },
       {
-        "command": "prismatic.refreshToken",
-        "title": "Refresh Token",
-        "category": "Prismatic",
-        "enablement": "prismatic.workspaceEnabled"
-      },
-      {
         "command": "prismatic.login",
         "title": "Login",
         "category": "Prismatic",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -302,24 +302,6 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(switchTenantCommand);
 
     /**
-     * command: prismatic.refreshToken
-     * This command is used to manually refresh the access token.
-     */
-    const prismRefreshTokenCommand = vscode.commands.registerCommand(
-      "prismatic.refreshToken",
-      async () => {
-        try {
-          await authManager.refreshAccessToken();
-
-          log("SUCCESS", "Successfully refreshed tokens!", true);
-        } catch (error) {
-          log("ERROR", String(error), true);
-        }
-      },
-    );
-    context.subscriptions.push(prismRefreshTokenCommand);
-
-    /**
      * This command is used to open the integration in browser.
      */
     const integrationOpenInBrowserCommand = vscode.commands.registerCommand(

--- a/src/extension/AuthManager.ts
+++ b/src/extension/AuthManager.ts
@@ -210,7 +210,7 @@ export class AuthManager {
     return tokens.accessToken;
   }
 
-  public async refreshAccessToken(): Promise<string> {
+  private async refreshAccessToken(): Promise<string> {
     const tokens = await this.secretStore.getTokens();
     if (!tokens?.refreshToken) {
       throw new Error("No refresh token found. Please login again.");


### PR DESCRIPTION
Token refresh is handled in-extension and shouldn't need the user to be aware of it. This removes the command to declutter the "command surface" of the extension a bit.